### PR TITLE
changed server name to `cat-api-wrapper`

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	s := &fasthttp.Server{
 		Handler:            requestHandler,
-		Name:               "srp-go",
+		Name:               "cat-api-wrapper",
 		MaxRequestBodySize: maxBodySize,
 	}
 


### PR DESCRIPTION
Looks like it was copied from [there](https://github.com/l1ving/srp-go/blob/2251406ae33620365e9245e0d62a9fb7ce4de3f9/main.go#L50)